### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/adityakalambe01/HotelManagement/security/code-scanning/1](https://github.com/adityakalambe01/HotelManagement/security/code-scanning/1)

The best way to fix this problem is to add a `permissions:` block to the workflow file (either at the top level, or under the affected job, `build`). Since the `build` job primarily checks out code and performs package installation/build/test, the minimal required permission is `contents: read` (which allows the job to checkout code). Unless the workflow contains steps that create new pull requests, issues, releases, etc., no additional permissions are needed. Place the block just below the workflow name (`name:`), before the `on:` trigger, to apply it to all jobs in the workflow unless overridden by job-specific settings.

No imports or special definitions are needed. Only a single new block to add.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
